### PR TITLE
Print warnings to log

### DIFF
--- a/deploy_s3.R
+++ b/deploy_s3.R
@@ -15,3 +15,5 @@ s3copy <- function(path, bucket, recursive = FALSE, ...){
 }
 status <- s3copy("src", "packages.ropensci.org", recursive = TRUE, region="us-west-2", 
        key = Sys.getenv("AWS_ACCESS_KEY_ID"), secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"))
+
+warnings()


### PR DESCRIPTION
If there are more than 50 warnings for packages that failed to deploy, no warnings are printed and the Circle CI logs read:

> There were 50 or more warnings (use warnings() to see the first 50)

This commit adds an explicit call to `warnings()` to print them.
