### PR TITLE
#12 fix to package paths, some ropensci, some ropenscilabs

### DIFF
--- a/ropensci.R
+++ b/ropensci.R
@@ -4,8 +4,8 @@ out <- ro_pkgs()
 good <- out$packages$status == "good"
 installable <- out$packages$installable
 exclude <- readLines("exclude.txt")
-blacklist <- out$packages$name %in% exclude 
-pkgs <- out$packages$name[installable & good & !blacklist]
+blacklist <- out$packages$name %in% exclude
+pkgs <- gsub("https://github.com/", "", out$packages$url)[installable & good & !blacklist]
 root <- out$packages$root[installable & good & !blacklist]
 
-writeLines(paste("ropensci", pkgs, root, sep="/"), "ropensci.txt")
+writeLines(paste(pkgs, root, sep="/"), "ropensci.txt")


### PR DESCRIPTION
uses the URL for each pkg, though we could add a separate field for owner/repo if you want
